### PR TITLE
fix: add extends support for v1.12+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,15 @@ notifications:
 node_js:
   - v10
   - v8
+env:
+  - PPTR_OVERRIDE_VERSION=1.5.x
+  - PPTR_OVERRIDE_VERSION=1.7.x
+  - PPTR_OVERRIDE_VERSION=1.12.x
+  - PPTR_OVERRIDE_VERSION=latest
 before_install:
   - npm install -g yarn coveralls nyc @patrickhulce/scripts
+before_script:
+  - npm install --no-save "puppeteer@${PPTR_OVERRIDE_VERSION}"
 script:
   - yarn rebuild
   - yarn test:lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,10 @@ env:
 before_install:
   - npm install -g yarn coveralls nyc @patrickhulce/scripts
 before_script:
-  - npm install --no-save "puppeteer@${PPTR_OVERRIDE_VERSION}"
+  - yarn add -D "puppeteer@${PPTR_OVERRIDE_VERSION}"
 script:
   - yarn rebuild
   - yarn test:lint
   - yarn test:unit --coverage --runInBand --verbose
 after_success:
   - cat coverage/lcov.info | coveralls || echo 'Failed to upload to coveralls...'
-  - hulk npm-publish --yes

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const $email = await getByLabelText($form, 'Email')
 // interact with puppeteer like usual
 await $email.type('pptr@example.com')
 // waiting works too!
-await wait(() => getByText('Loading...'))
+await wait(() => getByText($document, 'Loading...'))
 ```
 
 A little too un-puppeteer for you? We've got prototype-mucking covered too :)

--- a/lib/extend.ts
+++ b/lib/extend.ts
@@ -16,12 +16,15 @@ try {
   if (Page.Page) Page = Page.Page
 
   ElementHandle = requireOrUndefined('puppeteer/lib/ElementHandle.js') // tslint:disable-line variable-name
+  if (ElementHandle && ElementHandle.ElementHandle) ElementHandle = ElementHandle.ElementHandle
+
   if (!ElementHandle) {
     const ExecutionContext = requireOrUndefined('puppeteer/lib/ExecutionContext.js') // tslint:disable-line variable-name
     if (ExecutionContext && ExecutionContext.ElementHandle) {
       ElementHandle = ExecutionContext.ElementHandle
     }
   }
+  if (ElementHandle && ElementHandle.ElementHandle) ElementHandle = ElementHandle.ElementHandle
 
   if (!ElementHandle) {
     const JSHandle = require('puppeteer/lib/JSHandle.js') // tslint:disable-line
@@ -29,6 +32,7 @@ try {
       ElementHandle = JSHandle.ElementHandle
     }
   }
+  if (ElementHandle && ElementHandle.ElementHandle) ElementHandle = ElementHandle.ElementHandle
 
   Page.prototype.getDocument = getDocument
   getQueriesForElement(ElementHandle.prototype, function(this: ElementHandle): ElementHandle {

--- a/lib/extend.ts
+++ b/lib/extend.ts
@@ -15,9 +15,19 @@ try {
   Page = require('puppeteer/lib/Page.js') // tslint:disable-line
   if (Page.Page) Page = Page.Page
 
-  ElementHandle = requireOrUndefined('puppeteer/lib/ElementHandle.js') // tslint:disable-line
+  ElementHandle = requireOrUndefined('puppeteer/lib/ElementHandle.js') // tslint:disable-line variable-name
   if (!ElementHandle) {
-    ElementHandle = require('puppeteer/lib/ExecutionContext.js').ElementHandle // tslint:disable-line
+    const ExecutionContext = requireOrUndefined('puppeteer/lib/ExecutionContext.js') // tslint:disable-line variable-name
+    if (ExecutionContext && ExecutionContext.ElementHandle) {
+      ElementHandle = ExecutionContext.ElementHandle
+    }
+  }
+
+  if (!ElementHandle) {
+    const JSHandle = require('puppeteer/lib/JSHandle.js') // tslint:disable-line
+    if (JSHandle && JSHandle.ElementHandle) {
+      ElementHandle = JSHandle.ElementHandle
+    }
   }
 
   Page.prototype.getDocument = getDocument

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -39,15 +39,10 @@ interface IQueryMethods {
   getByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
 
-  queryBySelectText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
-  queryAllBySelectText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
-  getBySelectText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
-  getAllBySelectText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
-
-  queryByValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
-  queryAllByValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
-  getByValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
-  getAllByValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  queryByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
+  queryAllByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  getByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
+  getAllByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
 }
 
 type IScopedQueryMethods = {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     }
   },
   "dependencies": {
-    "dom-testing-library": "^3.11.0",
+    "dom-testing-library": "^4.1.1",
     "wait-for-expect": "^0.4.0"
   },
   "devDependencies": {
@@ -55,6 +55,7 @@
     "rollup": "^0.61.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",
+    "rollup-plugin-replace": "^2.2.0",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",
     "typescript": "^2.9.2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "dom-testing-library": "^4.1.1",
-    "wait-for-expect": "^0.4.0"
+    "wait-for-expect": "^1.2.0"
   },
   "devDependencies": {
     "@patrickhulce/lint": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/puppeteer": "^1.10.0",
     "generate-export-aliases": "^1.1.0",
     "jest": "^23.1.0",
-    "puppeteer": "^1.10.0",
+    "puppeteer": "^1.16.0",
     "rollup": "^0.61.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,5 +7,11 @@ module.exports = {
     format: 'iife',
     name: '__dom_testing_library__',
   },
-  plugins: [require('rollup-plugin-node-resolve')(), require('rollup-plugin-commonjs')()],
+  plugins: [
+    require('rollup-plugin-node-resolve')(),
+    require('rollup-plugin-commonjs')(),
+    require('rollup-plugin-replace')({
+      'process.env.NODE_ENV': JSON.stringify('development'),
+    }),
+  ],
 }

--- a/test/__snapshots__/extend.test.ts.snap
+++ b/test/__snapshots__/extend.test.ts.snap
@@ -16,11 +16,10 @@ exports[`lib/extend.ts should handle the get* method failures 1`] = `
   
   
 </div>
-    at getElementError <stack>:X:X)
-    at getAllByTitle <stack>:X:X)
-    at firstResultOrNull <stack>:X:X)
-    at Object.getByTitle <stack>:X:X)
-    at anonymous <stack>:X:X)"
+    at getElementError <stack>:X:X
+    at __puppeteer_evaluation_script__<stack>:X:X
+    at Object.<anonymous> <stack>:X:X
+    at anonymous <stack>:X:X"
 `;
 
 exports[`lib/extend.ts should handle the get* methods 1`] = `"<input type=\\"text\\" data-testid=\\"testid-text-input\\">"`;

--- a/test/__snapshots__/extend.test.ts.snap
+++ b/test/__snapshots__/extend.test.ts.snap
@@ -16,10 +16,7 @@ exports[`lib/extend.ts should handle the get* method failures 1`] = `
   
   
 </div>
-    at getElementError <stack>:X:X
-    at __puppeteer_evaluation_script__<stack>:X:X
-    at Object.<anonymous> <stack>:X:X
-    at anonymous <stack>:X:X"
+    <stack>:X:X"
 `;
 
 exports[`lib/extend.ts should handle the get* methods 1`] = `"<input type=\\"text\\" data-testid=\\"testid-text-input\\">"`;

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -36,7 +36,7 @@ describe('lib/extend.ts', () => {
   })
 
   it('should handle regex matching', async () => {
-    const element = await document.queryByText(/HeLlO/i)
+    const element = await document.queryByText(/HeLlO h(1|7)/i)
     expect(element).toBeTruthy()
     /* istanbul ignore next */
     expect(await page.evaluate(el => el.textContent, element)).toEqual('Hello h1')
@@ -56,7 +56,7 @@ describe('lib/extend.ts', () => {
       await scope.getByTitle('missing')
       fail()
     } catch (err) {
-      err.message = err.message.replace(/\(.*?:\d+:\d+/g, '<stack>:X:X')
+      err.message = err.message.replace(/(\(.*?)?:\d+:\d+\)?/g, '<stack>:X:X')
       expect(err.message).toMatchSnapshot()
     }
   })

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -56,7 +56,7 @@ describe('lib/extend.ts', () => {
       await scope.getByTitle('missing')
       fail()
     } catch (err) {
-      err.message = err.message.replace(/(\(.*?)?:\d+:\d+\)?/g, '<stack>:X:X')
+      err.message = err.message.replace(/(\s*at .*(\n|$))+/gm, '\n    <stack>:X:X')
       expect(err.message).toMatchSnapshot()
     }
   })

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -1,11 +1,14 @@
 import * as path from 'path'
 import * as puppeteer from 'puppeteer'
-import '../lib/extend'
 
 describe('lib/extend.ts', () => {
   let browser: puppeteer.Browser
   let page: puppeteer.Page
   let document: puppeteer.ElementHandle
+
+  it('should require without error', async () => {
+    await import('../lib/extend')
+  })
 
   it('should launch puppeteer', async () => {
     browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']})

--- a/test/fixtures/late-page.html
+++ b/test/fixtures/late-page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <span>Loading...</span>
+    <script>
+      setTimeout(() => {
+        const loaded = document.createElement('span')
+        loaded.textContent = 'Loaded!'
+        document.body.appendChild(loaded)
+      }, 5000)
+    </script>
+  </body>
+</html>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import * as puppeteer from 'puppeteer'
-import {getDocument, queries, getQueriesForElement} from '../lib'
+import {getDocument, queries, getQueriesForElement, wait} from '../lib'
 
 describe('lib/index.ts', () => {
   let browser: puppeteer.Browser
@@ -23,6 +23,16 @@ describe('lib/index.ts', () => {
     const element = await getByText('Hello h1')
     expect(await queries.getNodeText(element)).toEqual('Hello h1')
   })
+
+  it('should load the defered page', async () => {
+    await page.goto(`file://${path.join(__dirname, 'fixtures/late-page.html')}`)
+  })
+
+  it('should use `wait` properly', async () => {
+    const {getByText} = getQueriesForElement(await getDocument(page))
+    await wait(() => getByText('Loaded!'))
+    expect(await getByText('Loaded!')).toBeTruthy()
+  }, 7000)
 
   afterAll(async () => {
     await browser.close()

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -30,9 +30,9 @@ describe('lib/index.ts', () => {
 
   it('should use `wait` properly', async () => {
     const {getByText} = getQueriesForElement(await getDocument(page))
-    await wait(() => getByText('Loaded!'))
+    await wait(() => getByText('Loaded!'), {timeout: 7000})
     expect(await getByText('Loaded!')).toBeTruthy()
-  }, 7000)
+  }, 9000)
 
   afterAll(async () => {
     await browser.close()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,13 @@
     "sourceMap": true,
     "declaration": true,
 
+    "skipLibCheck": true,
+
     "strict": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
-    "preserveWatchOutput": true,
+    "preserveWatchOutput": true
   },
-  "include": [
-    "lib/**/*"
-  ]
+  "include": ["lib/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5564,12 +5564,7 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-for-expect@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-0.4.0.tgz#341c96ab89d6102a0169a9be6cd0de354de92c17"
-  integrity sha512-itHoJUKL5P8abjhWRlp3F5QLDY7LokcJkgD78tjrX08ozBakfy9YD4bgxUVuSld8yqjza3ld6Sj7UMMOH/twFA==
-
-wait-for-expect@^1.1.1:
+wait-for-expect@^1.1.1, wait-for-expect@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
   integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,22 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.4.3":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@jest/types@^24.8.0":
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad"
+  integrity sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^12.0.9"
+
 "@patrickhulce/lint@^2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@patrickhulce/lint/-/lint-2.1.3.tgz#736a72de4be852829bc77de3f1690f5af5580348"
@@ -46,6 +62,26 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
+  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+
+"@types/istanbul-lib-report@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
+  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
+  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
 "@types/jest@^23.1.1":
   version "23.1.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.1.1.tgz#c54ab1a5f41aa693c0957222dd10414416d0c87b"
@@ -62,6 +98,11 @@
   integrity sha512-qrDx+mdV3jj5GYVW9rh8upVt+Hu6xUKerOJE5ko7bSm3aagqKybhwSsQvLqaZJzNs0vbyvtX0wTgs/H/ZvORCA==
   dependencies:
     "@types/node" "*"
+
+"@types/yargs@^12.0.9":
+  version "12.0.12"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
+  integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
 abab@^1.0.4:
   version "1.0.4"
@@ -165,6 +206,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -1330,14 +1376,15 @@ doctrine@^2.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-testing-library@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.11.0.tgz#374fbc1f4b61405ac10a27cb3a6d3912c3ed1dd3"
-  integrity sha512-YOrbercTdYvfwkKdiSQXwrQKHbuSYz2DF4f9t9zXCTg+KThWQ15T2MOzWun8GuLx8JaToEsMsoZG3KAdapDzTA==
+dom-testing-library@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-4.1.1.tgz#615af61bee06db51bd8ecea60c113eba7cb49dda"
+  integrity sha512-PUsG7aY5BJxzulDrOtkksqudRRypcVQF6d4RGAyj9xNwallOFqrNLOyg2QW2mCpFaNVPELX8hBX/wbHQtOto/A==
   dependencies:
+    "@babel/runtime" "^7.4.3"
     "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^23.6.0"
-    wait-for-expect "^1.0.0"
+    pretty-format "^24.7.0"
+    wait-for-expect "^1.1.1"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -1679,6 +1726,11 @@ estree-walker@^0.5.1, estree-walker@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
   integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
+
+estree-walker@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
+  integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -3550,6 +3602,13 @@ magic-string@^0.22.4:
   dependencies:
     vlq "^0.2.2"
 
+magic-string@^0.25.2:
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.2.tgz#139c3a729515ec55e96e69e82a11fe890a293ad9"
+  integrity sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3625,7 +3684,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4, micromatch@^3.1.8:
+micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -4278,13 +4337,15 @@ pretty-format@^23.0.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
-  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
+pretty-format@^24.7.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
+  integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
   dependencies:
-    ansi-regex "^3.0.0"
+    "@jest/types" "^24.8.0"
+    ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
+    react-is "^16.8.4"
 
 private@^0.1.8:
   version "0.1.8"
@@ -4415,6 +4476,11 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-is@^16.8.4:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -4499,6 +4565,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -4685,6 +4756,14 @@ rollup-plugin-node-resolve@^3.3.0:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
+rollup-plugin-replace@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
+  dependencies:
+    magic-string "^0.25.2"
+    rollup-pluginutils "^2.6.0"
+
 rollup-pluginutils@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz#478ace04bd7f6da2e724356ca798214884738fc4"
@@ -4692,6 +4771,14 @@ rollup-pluginutils@^2.0.1:
   dependencies:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
+
+rollup-pluginutils@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz#a7915ce8b12c177364784bf38a1590cc6c2c8250"
+  integrity sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==
+  dependencies:
+    estree-walker "^0.6.0"
+    micromatch "^3.1.10"
 
 rollup@^0.61.1:
   version "0.61.1"
@@ -4932,6 +5019,11 @@ source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz#c63ea927c029dd6bd9a2b7fa03b3fec02ad56e9f"
+  integrity sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==
 
 spdx-correct@^3.0.0:
   version "3.0.0"
@@ -5477,10 +5569,10 @@ wait-for-expect@^0.4.0:
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-0.4.0.tgz#341c96ab89d6102a0169a9be6cd0de354de92c17"
   integrity sha512-itHoJUKL5P8abjhWRlp3F5QLDY7LokcJkgD78tjrX08ozBakfy9YD4bgxUVuSld8yqjza3ld6Sj7UMMOH/twFA==
 
-wait-for-expect@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.0.1.tgz#73ab346ed56ed2ef66c380a59fd623755ceac0ce"
-  integrity sha512-TPZMSxGWUl2DWmqdspLDEy97/S1Mqq0pzbh2A7jTq0WbJurUb5GKli+bai6ayeYdeWTF0rQNWZmUvCVZ9gkrfA==
+wait-for-expect@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,6 +1189,13 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -3734,6 +3741,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -4294,10 +4306,10 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
-progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
-  integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 proxy-from-env@^1.0.0:
   version "1.0.0"
@@ -4340,19 +4352,19 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.10.0.tgz#e3005f1251c2feae0e10c0f7a35afbcd56589ceb"
-  integrity sha512-3i28X/ucX8t3eL4TZA60FLMOQNKqudFSOGDHr0cT7T4dE027CrcS885aAqjdxNybhMPliM5yImNsKJ6SQrPzhw==
+puppeteer@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.16.0.tgz#4b763d9ff4e69a4bb7a031c3393534214d54f27e"
+  integrity sha512-7hcmbUw+6INffSPBdnO8KSjJRg2bLRoI7EeZMf5MHdV5kpyYMeoMR5w8AIiZbKIhYGwrXlbgvO7gFTsXNHShuQ==
   dependencies:
-    debug "^3.1.0"
+    debug "^4.1.0"
     extract-zip "^1.6.6"
     https-proxy-agent "^2.2.1"
     mime "^2.0.3"
-    progress "^2.0.0"
+    progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
-    ws "^5.1.1"
+    ws "^6.1.0"
 
 qs@~6.5.1:
   version "6.5.2"
@@ -5592,10 +5604,10 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
-ws@^5.1.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
-  integrity sha512-c18dMeW+PEQdDFzkhDsnBAlS4Z8KGStBQQUcQ5mf7Nf689jyGk0594L+i9RaQuf4gog6SvWLJorz2NfSaqxZ7w==
+ws@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
ElementHandle was moved again in https://github.com/GoogleChrome/puppeteer/commit/e8bb26eb956fad53f59da315374367671c6c8eba

I'll throw some travis tests in here for more pptr versions too