### PR TITLE
feat: update supported node versions to 10 and 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache: yarn
 notifications:
   email: false
 node_js:
+  - v12
   - v10
-  - v8
 env:
   - PPTR_OVERRIDE_VERSION=1.5.x
   - PPTR_OVERRIDE_VERSION=1.7.x

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   },
   "peerDependencies": {
     "puppeteer": "^1.5.0 || ^2.0.0"
+  },
+  "engines": {
+    "node": "^10 || ^12"
   }
 }


### PR DESCRIPTION
- Node 8 is no longer getting security updates. https://nodejs.org/en/about/releases/
- Rollup 2 requires node 10