### PR TITLE
feat: export configure function with data-testid override

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import {ElementHandle, EvaluateFn, JSHandle, Page} from 'puppeteer'
 import waitForExpect from 'wait-for-expect'
 
-import {IQueryUtils, IScopedQueryUtils, IConfigureOptions} from './typedefs'
+import {IConfigureOptions, IQueryUtils, IScopedQueryUtils} from './typedefs'
 
 const domLibraryAsString = readFileSync(
   path.join(__dirname, '../dom-testing-library.js'),
@@ -132,17 +132,17 @@ export function wait(
   return waitForExpect(callback, timeout, interval)
 }
 
-export function configure(options: Partial<IConfigureOptions>) {
+export function configure(options: Partial<IConfigureOptions>): void {
   if (!options) {
     return
   }
 
-  const { testIdAttribute } = options;
+  const { testIdAttribute } = options
 
-  if (testIdAttribute && typeof testIdAttribute === 'string') {
+  if (testIdAttribute) {
     delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPageInitial.replace(
       /testIdAttribute: (['|"])data-testid(['|"])/g,
-      `testIdAttribute: $1${testIdAttribute}$2`
+      `testIdAttribute: $1${testIdAttribute}$2`,
     )
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -133,6 +133,10 @@ export function wait(
 }
 
 export function configure(options: Partial<IConfigureOptions>) {
+  if (!options) {
+    return
+  }
+
   const { testIdAttribute } = options;
 
   if (testIdAttribute && typeof testIdAttribute === 'string') {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import {ElementHandle, EvaluateFn, JSHandle, Page} from 'puppeteer'
 import waitForExpect from 'wait-for-expect'
 
-import {IQueryUtils, IScopedQueryUtils} from './typedefs'
+import {IQueryUtils, IScopedQueryUtils, Config} from './typedefs'
 
 const domLibraryAsString = readFileSync(
   path.join(__dirname, '../dom-testing-library.js'),
@@ -17,7 +17,7 @@ function mapArgument(argument: any, index: number): any {
     : argument
 }
 
-const delegateFnBodyToExecuteInPage = `
+let delegateFnBodyToExecuteInPage = `
   ${domLibraryAsString};
 
   const mappedArgs = args.map(${mapArgument.toString()});
@@ -128,6 +128,21 @@ export function wait(
   {timeout = 4500, interval = 50}: {timeout?: number; interval?: number} = {},
 ): Promise<{}> {
   return waitForExpect(callback, timeout, interval)
+}
+
+export function configure(newConfig: Partial<Config>) {
+  const { testIdAttribute } = newConfig;
+
+  if (
+    testIdAttribute &&
+    typeof testIdAttribute === 'string' &&
+    testIdAttribute !== ''
+  ) {
+    delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPage.replace(
+      `testIdAttribute: 'data-testid'`,
+      `testIdAttribute: '${newConfig.testIdAttribute}'`
+    )
+  }
 }
 
 export function getQueriesForElement<T>(

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -60,5 +60,5 @@ export interface IQueryUtils extends IQueryMethods {
 }
 
 export interface IConfigureOptions {
-  testIdAttribute: string;
+  testIdAttribute: string
 }

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -59,6 +59,6 @@ export interface IQueryUtils extends IQueryMethods {
   getNodeText(el: Element): Promise<string>
 }
 
-export interface Config {
+export interface IConfigureOptions {
   testIdAttribute: string;
 }

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -58,3 +58,7 @@ export interface IQueryUtils extends IQueryMethods {
   getQueriesForElement(): IQueryUtils & IScopedQueryUtils
   getNodeText(el: Element): Promise<string>
 }
+
+export interface Config {
+  testIdAttribute: string;
+}

--- a/test/fixtures/page.html
+++ b/test/fixtures/page.html
@@ -3,7 +3,7 @@
 
 <body>
   <h1>Hello h1</h1>
-  <h2>Hello h2</h2>
+  <h2 data-id="my-header">Hello h2</h2>
   <img alt="Image A" src="">
   <input type="text" data-testid="testid-text-input">
   <label for="label-text-input">Label A</label>

--- a/test/fixtures/page.html
+++ b/test/fixtures/page.html
@@ -6,7 +6,7 @@
   <h2 data-id="second-level-header">Hello h2</h2>
   <img alt="Image A" src="">
   <input type="text" data-testid="testid-text-input">
-  <label for="label-text-input">Label A</label>
+  <label for="label-text-input" data-testid="testid-label">Label A</label>
   <input id="label-text-input" type="text">
 
   <div id="scoped">

--- a/test/fixtures/page.html
+++ b/test/fixtures/page.html
@@ -2,8 +2,8 @@
 <html>
 
 <body>
-  <h1>Hello h1</h1>
-  <h2 data-id="my-header">Hello h2</h2>
+  <h1 data-new-id="first-level-header">Hello h1</h1>
+  <h2 data-id="second-level-header">Hello h2</h2>
   <img alt="Image A" src="">
   <input type="text" data-testid="testid-text-input">
   <label for="label-text-input">Label A</label>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,7 +17,7 @@ describe('lib/index.ts', () => {
     const element = await queries.getByText(document, 'Hello h1')
     expect(await queries.getNodeText(element)).toEqual('Hello h1')
   })
-  
+
   it('should support custom data-testid attribute name', async () => {
     configure({testIdAttribute: 'data-id'})
     const document = await getDocument(page)
@@ -31,6 +31,15 @@ describe('lib/index.ts', () => {
     const document = await getDocument(page)
     const element = await queries.getByTestId(document, 'first-level-header')
     expect(await queries.getNodeText(element)).toEqual('Hello h1')
+  })
+
+  it('should keep the default data-testid when input passed is invalid', async () => {
+    ;[{}, undefined, null, {testIdAttribute: ''}].forEach(async options => {
+      const document = await getDocument(page)
+      configure(options as any)
+      const element = await queries.getByTestId(document, 'testid-label')
+      expect(await queries.getNodeText(element)).toEqual('Label A')
+    })
   })
 
   it('should support regex on raw queries object', async () => {
@@ -55,6 +64,10 @@ describe('lib/index.ts', () => {
     await wait(() => getByText('Loaded!'), {timeout: 7000})
     expect(await getByText('Loaded!')).toBeTruthy()
   }, 9000)
+
+  afterEach(() => {
+    configure({testIdAttribute: 'data-testid'}) //cleanup
+  })
 
   afterAll(async () => {
     await browser.close()

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import * as puppeteer from 'puppeteer'
-import {getDocument, queries, getQueriesForElement, wait} from '../lib'
+import {getDocument, queries, getQueriesForElement, wait, configure} from '../lib'
 
 describe('lib/index.ts', () => {
   let browser: puppeteer.Browser
@@ -16,6 +16,13 @@ describe('lib/index.ts', () => {
     const document = await getDocument(page)
     const element = await queries.getByText(document, 'Hello h1')
     expect(await queries.getNodeText(element)).toEqual('Hello h1')
+  })
+  
+  it('should support custom data-testid names', async () => {
+    configure({testIdAttribute: 'data-id'})
+    const document = await getDocument(page)
+    const element = await queries.getByTestId(document, 'my-header')
+    expect(await queries.getNodeText(element)).toEqual('Hello h2')
   })
 
   it('should support regex on raw queries object', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,11 +18,19 @@ describe('lib/index.ts', () => {
     expect(await queries.getNodeText(element)).toEqual('Hello h1')
   })
   
-  it('should support custom data-testid names', async () => {
+  it('should support custom data-testid attribute name', async () => {
     configure({testIdAttribute: 'data-id'})
     const document = await getDocument(page)
-    const element = await queries.getByTestId(document, 'my-header')
+    const element = await queries.getByTestId(document, 'second-level-header')
     expect(await queries.getNodeText(element)).toEqual('Hello h2')
+  })
+
+  it('should support subsequent changing the data-testid attribute names', async () => {
+    configure({testIdAttribute: 'data-id'})
+    configure({testIdAttribute: 'data-new-id'})
+    const document = await getDocument(page)
+    const element = await queries.getByTestId(document, 'first-level-header')
+    expect(await queries.getNodeText(element)).toEqual('Hello h1')
   })
 
   it('should support regex on raw queries object', async () => {


### PR DESCRIPTION
Closes https://github.com/testing-library/pptr-testing-library/issues/32.

Replaces all occurrences of `testIdAttribute: 'data-testid'` with `testIdAttribute: '<custom-attribute-name>'` in the imported stringified `dom-testing-library`. Also keeps the original string just in case we need to perform subsequent changes.

Adds 2 unit tests to cover the changes.

Adds a new type that accepts only the supported parameter from `configure`.
```ts
export interface IConfigureOptions {
  testIdAttribute: string;
}
```

