### PR TITLE
Add findBy* queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,30 +73,41 @@ Unique methods, not part of `@testing-library/dom`
   - `queryAllByPlaceholderText`
   - `getByPlaceholderText`
   - `getAllByPlaceholderText`
+  - `findByPlaceholderText`
+  - `findAllByPlaceholderText`
   - `queryByText`
   - `queryAllByText`
   - `getByText`
   - `getAllByText`
+  - `findByText`
+  - `findAllByText`
   - `queryByLabelText`
   - `queryAllByLabelText`
   - `getByLabelText`
   - `getAllByLabelText`
+  - `findByLabelText`
+  - `findAllByLabelText`
   - `queryByAltText`
   - `queryAllByAltText`
   - `getByAltText`
   - `getAllByAltText`
+  - `findByAltText`
+  - `findAllByAltText`
   - `queryByTestId`
   - `queryAllByTestId`
   - `getByTestId`
   - `getAllByTestId`
+  - `findByTestId`
+  - `findAllByTestId`
   - `queryByTitle`
   - `queryAllByTitle`
   - `getByTitle`
   - `getAllByTitle`
+  - `findByTitle`
+  - `findAllByTitle`
 
 ## Known Limitations
 
-- `waitForElement` method is not exposed. Puppeteer has its own set of wait utilities that somewhat conflict with the style used in `@testing-library/dom`. See [#3](https://github.com/testing-library/pptr-testing-library/issues/3).
 - `fireEvent` method is not exposed, use puppeteer's built-ins instead.
 - `expect` assertion extensions are not available.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Unique methods, not part of `@testing-library/dom`
   - `getAllByTitle`
   - `findByTitle`
   - `findAllByTitle`
+  - `queryByDisplayValue`,
+  - `queryAllByDisplayValue`,
+  - `getByDisplayValue`,
+  - `getAllByDisplayValue`,
+  - `findByDisplayValue`,
+  - `findAllByDisplayValue`,
 
 ## Known Limitations
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -161,41 +161,57 @@ export function getQueriesForElement<T>(
     'queryAllByPlaceholderText',
     'getByPlaceholderText',
     'getAllByPlaceholderText',
+    'findByPlaceholderText',
+    'findAllByPlaceholderText',
 
     'queryByText',
     'queryAllByText',
     'getByText',
     'getAllByText',
+    'findByText',
+    'findAllByText',
 
     'queryByLabelText',
     'queryAllByLabelText',
     'getByLabelText',
     'getAllByLabelText',
+    'findByLabelText',
+    'findAllByLabelText',
 
     'queryByAltText',
     'queryAllByAltText',
     'getByAltText',
     'getAllByAltText',
+    'findByAltText',
+    'findAllByAltText',
 
     'queryByTestId',
     'queryAllByTestId',
     'getByTestId',
     'getAllByTestId',
+    'findByTestId',
+    'findAllByTestId',
 
     'queryByTitle',
     'queryAllByTitle',
     'getByTitle',
     'getAllByTitle',
+    'findByTitle',
+    'findAllByTitle',
 
     'queryByRole',
     'queryAllByRole',
     'getByRole',
     'getAllByRole',
+    'findByRole',
+    'findAllByRole',
 
     'queryByDisplayValue',
     'queryAllByDisplayValue',
     'getByDisplayValue',
     'getAllByDisplayValue',
+    'findByDisplayValue',
+    'findAllByDisplayValue',
   ]
   functionNames.forEach(functionName => {
     o[functionName] = createDelegateFor(functionName, contextFn)

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -1,4 +1,4 @@
-import {Matcher, MatcherOptions, SelectorMatcherOptions} from '@testing-library/dom'
+import {BoundFunctions, Matcher, MatcherOptions, SelectorMatcherOptions, WaitForElementOptions} from '@testing-library/dom'
 import {ElementHandle} from 'puppeteer'
 
 type Element = ElementHandle
@@ -8,54 +8,66 @@ interface IQueryMethods {
   queryAllByPlaceholderText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
   getByPlaceholderText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByPlaceholderText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  findByPlaceholderText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByPlaceholderText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element | null>
   queryAllByText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element[]>
   getByText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element>
   getAllByText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element[]>
+  findByText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByLabelText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element | null>
   queryAllByLabelText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element[]>
   getByLabelText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element>
   getAllByLabelText(el: Element, m: Matcher, opts?: SelectorMatcherOptions): Promise<Element[]>
+  findByLabelText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByLabelText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByAltText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
   queryAllByAltText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
   getByAltText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByAltText(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  findByAltText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByAltText(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByTestId(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
   queryAllByTestId(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
   getByTestId(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByTestId(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  findByTestId(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByTestId(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByTitle(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
   queryAllByTitle(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
   getByTitle(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByTitle(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  findByTitle(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByTitle(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
   queryAllByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
   getByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByRole(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  findByRole(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByRole(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 
   queryByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element | null>
   queryAllByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
   getByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element>
   getAllByDisplayValue(el: Element, m: Matcher, opts?: MatcherOptions): Promise<Element[]>
+  findByDisplayValue(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element>
+  findAllByDisplayValue(el: Element, m: Matcher, opts?: SelectorMatcherOptions, waitForOpts?: WaitForElementOptions): Promise<Element[]>
 }
 
-type IScopedQueryMethods = {
-  [K in keyof IQueryMethods]: (m: Matcher, opts?: MatcherOptions) => ReturnType<IQueryMethods[K]>
-}
-
-export interface IScopedQueryUtils extends IScopedQueryMethods {
-  getQueriesForElement(): IQueryUtils & IScopedQueryUtils
+export interface IScopedQueryUtils extends BoundFunctions<IQueryMethods> {
+  getQueriesForElement(): IScopedQueryUtils
   getNodeText(): Promise<string>
 }
 
 export interface IQueryUtils extends IQueryMethods {
-  getQueriesForElement(): IQueryUtils & IScopedQueryUtils
+  getQueriesForElement(): BoundFunctions<IQueryUtils>
   getNodeText(el: Element): Promise<string>
 }
 

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -100,6 +100,29 @@ describe('lib/extend.ts', () => {
     expect(await queryByText('Hello h3')).toBeTruthy()
   })
 
+  describe('deferred page', () => {
+    beforeEach(async () => {
+      await page.goto(`file://${path.join(__dirname, 'fixtures/late-page.html')}`)
+      document = await page.getDocument()
+    })
+
+    it('should handle the findBy* methods', async () => {
+      expect(await document.findByText('Loaded!', {}, { timeout: 7000 })).toBeTruthy()
+    }, 9000)
+
+    it('should handle the findByAll* methods', async () => {
+      const elements = await document.findAllByText(/Hello/, {}, { timeout: 7000 })
+      expect(elements).toHaveLength(2)
+
+      const text = await Promise.all([
+        page.evaluate(el => el.textContent, elements[0]),
+        page.evaluate(el => el.textContent, elements[1]),
+      ])
+
+      expect(text).toEqual(['Hello h1', 'Hello h2'])
+    }, 9000)
+  })
+
   afterAll(async () => {
     await browser.close()
   })

--- a/test/fixtures/late-page.html
+++ b/test/fixtures/late-page.html
@@ -7,6 +7,14 @@
         const loaded = document.createElement('span')
         loaded.textContent = 'Loaded!'
         document.body.appendChild(loaded)
+
+        const heading1 = document.createElement('h1')
+        heading1.textContent = 'Hello h1'
+        document.body.appendChild(heading1)
+
+        const heading2 = document.createElement('h2')
+        heading2.textContent = 'Hello h2'
+        document.body.appendChild(heading2)
       }, 5000)
     </script>
   </body>


### PR DESCRIPTION
Adds all the `findBy*` queries from dom-testing-library.

This should be quite useful given the asynchronous nature of E2E tests. 

I have also updated the README to remove `waitForElement` as a known limitation, as it is [deprecated](https://testing-library.com/docs/dom-testing-library/api-async#waitforelement-deprecated-use-find-queries-or-waitfor) in `dom-testing-library` and the recommended alternative is `find*` queries or `waitFor` which should now be supported!.