### PR TITLE
misc: drop support for node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "puppeteer": "*"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: node 10 is no longer supported. It reached its end-of-life on 30.04.2021.