### PR TITLE
Update TypeScript target to match NodeJS 12

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": true,
   "compilerOptions": {
     "outDir": "./dist",
-    "target": "es2015",
+    "target": "es2017",
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
Since the package.json specifies that the min NodeJS version is 12, I've updated the TypeScript to target es2017. The only change this has in the output is that async/await is no longer downleveled and is left as-is since NodeJS 12 supports async/await natively 🎉

I came across this while debugging locally in my node_modules and not having to jump through TypeScript's `__awaiter` helper would make this easier, at least for users like me 😅