### PR TITLE
Support global timeout

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,6 +56,12 @@ const delegateFnBodyToExecuteInPageInitial = `
 
 let delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPageInitial
 
+let config: Partial<IConfigureOptions> = {
+  asyncUtilTimeout: 4500
+}
+
+configure(config)
+
 type DOMReturnType = ElementHandle | ElementHandle[] | null
 
 type ContextFn = (...args: any[]) => ElementHandle
@@ -156,7 +162,7 @@ export async function getDocument(_page?: Page): Promise<ElementHandle> {
 
 export function wait(
   callback: () => void,
-  {timeout = 4500, interval = 50}: {timeout?: number; interval?: number} = {},
+  {timeout = config.asyncUtilTimeout, interval = 50}: {timeout?: number; interval?: number} = {},
 ): Promise<{}> {
   return waitForExpect(callback, timeout, interval)
 }
@@ -168,13 +174,22 @@ export function configure(options: Partial<IConfigureOptions>): void {
     return
   }
 
-  const {testIdAttribute} = options
+  config = {
+    ...config,
+    ...options,
+  }
+
+  const {testIdAttribute, asyncUtilTimeout} = config
 
   if (testIdAttribute) {
-    delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPageInitial.replace(
+    delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPage.replace(
       /testIdAttribute: (['|"])data-testid(['|"])/g,
       `testIdAttribute: $1${testIdAttribute}$2`,
     )
+  }
+
+  if (asyncUtilTimeout) {
+    delegateFnBodyToExecuteInPage = delegateFnBodyToExecuteInPage.replace(/asyncUtilTimeout: ([-+]?\d*\.?\d+)(?:[eE]([-+]?\d+))?/g, `asyncUtilTimeout: ${asyncUtilTimeout}`)
   }
 }
 

--- a/lib/typedefs.ts
+++ b/lib/typedefs.ts
@@ -176,5 +176,6 @@ export interface IQueryUtils extends IQueryMethods {
 }
 
 export interface IConfigureOptions {
-  testIdAttribute: string
+  testIdAttribute: string,
+  asyncUtilTimeout: number
 }

--- a/test/extend.test.ts
+++ b/test/extend.test.ts
@@ -132,11 +132,11 @@ describe('lib/extend.ts', () => {
     })
 
     it('should handle the findBy* methods', async () => {
-      expect(await document.findByText('Loaded!', {}, {timeout: 7000})).toBeTruthy()
-    }, 9000)
+      expect(await document.findByText('Loaded!')).toBeTruthy()
+    })
 
     it('should handle the findByAll* methods', async () => {
-      const elements = await document.findAllByText(/Hello/, {}, {timeout: 7000})
+      const elements = await document.findAllByText(/Hello/)
       expect(elements).toHaveLength(2)
 
       const text = await Promise.all([
@@ -145,7 +145,7 @@ describe('lib/extend.ts', () => {
       ])
 
       expect(text).toEqual(['Hello h1', 'Hello h2'])
-    }, 9000)
+    })
   })
 
   afterAll(async () => {

--- a/test/fixtures/late-page.html
+++ b/test/fixtures/late-page.html
@@ -15,7 +15,7 @@
         const heading2 = document.createElement('h2')
         heading2.textContent = 'Hello h2'
         document.body.appendChild(heading2)
-      }, 5000)
+      }, 3000)
     </script>
   </body>
 </html>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,6 +18,20 @@ describe('lib/index.ts', () => {
     expect(await queries.getNodeText(element)).toEqual('Hello h1')
   })
 
+  it('should support custom global timeout', async () => {
+    configure({asyncUtilTimeout: 2000})
+    let timeout1 = false
+    let timeout2 = false
+    setTimeout(() => {
+      timeout1 = true
+    }, 1000)
+    setTimeout(() => {
+      timeout2 = true
+    }, 3000)
+    await waitFor(() => expect(timeout1).toBe(true))
+    expect(timeout2).toBe(false)
+  })
+
   it('should support custom data-testid attribute name', async () => {
     configure({testIdAttribute: 'data-id'})
     const document = await getDocument(page)
@@ -66,7 +80,7 @@ describe('lib/index.ts', () => {
   }, 9000)
 
   afterEach(() => {
-    configure({testIdAttribute: 'data-testid'}) //cleanup
+    configure({testIdAttribute: 'data-testid', asyncUtilTimeout: 4500}) //cleanup
   })
 
   afterAll(async () => {


### PR DESCRIPTION
Added support for a global timeout configuration, follows the [specification of `asyncUtilTimeout`](https://testing-library.com/docs/dom-testing-library/api-configuration/#asyncutiltimeout).
In order to achieve this goal, we had to manipulate the "dom-testing-library.js" file (similar to how it's being done today to support `testIdAttribute` configuration), and replace all occurrences of `asyncUtilTimeout` with our config. We used a regex to match [floating-point numbers with an optional exponent](https://rgxdb.com/r/1RSPF8MG), because [esbuild formats "1000" to "1e3"](https://github.com/evanw/esbuild/blob/e8768569a042be09be0b01445fbe399ed043793b/internal/js_printer/js_printer.go#L2725). 

Moreover, we add & change tests so we can verify the global timeout works with this library `waitFor` method, and also with the `findBy*` query from the "dom-testing-library".

Relates to ticket #71 